### PR TITLE
Draw stopped ball with flicker fade effect.

### DIFF
--- a/src/app/game.asm
+++ b/src/app/game.asm
@@ -42,6 +42,7 @@ Game::
 	call gfx_load_game_obj
 	call gfx_load_bg_tiles
 	call stats_init
+	call Effects_init
 	call Collide_init
 	call things_init
 	call tcm_init
@@ -138,17 +139,7 @@ _Game_update:
 .things_done
 	call things_draw
 	call Ball_draw
-
-	ld a, [wLastBall_status]
-	and a
-	jr z, :+
-	ld a, [wLastBall_x]
-	ld b, a
-	ld a, [wLastBall_y]
-	ld c, a
-	call nz, Effects_draw_ball_stopped
-:
-
+	call Effects_update
 	ret
 
 

--- a/src/app/shotctl/phase_done.asm
+++ b/src/app/shotctl/phase_done.asm
@@ -31,7 +31,6 @@ _shot_done_update:
 	ld a, ShotPhaseStatus_NEXT
 	ld [wShot_phase_status], a
 :
-
 	ret
 
 
@@ -40,9 +39,15 @@ _shot_done_enter:
 	ld a, [hl+]
 	ld [hl+], a ; timer
 
-	call Ball_reset
+	call Ball_get_screen_position
+	ld hl, wBallSprite.sprite
+	ld a, [hl+]
+	ld e, a
+	ld a, [hl+]
+	ld d, a
+	call Effects_spawn_flicker_out
 
+	call Ball_reset
 	ld a, ShotPhaseStatus_OK
 	ld [wShot_phase_status], a
-
 	ret


### PR DESCRIPTION
A simple flicker effect is used for a period before the ball disappears completely.
Replaces static split ball sprite.
The sprite used is the frame that was being used by the actual ball when it stopped. This ensures continuity between the dynamic ball and the 'stopped ball' effect.

Could be improved further, but so could everything -- resolves #34 