### PR TITLE
Update Thing colliders before each shot.

### DIFF
--- a/src/app/game.asm
+++ b/src/app/game.asm
@@ -111,6 +111,10 @@ _Game_on_shot_event:
 
 
 _Game_on_shot_phase_changed:
+	ld a, [wShot_phase]
+	cp ShotPhase__SETUP
+	call z, things_update_colliders
+
 	; show status line
 	call build_status_stats
 	call status_update

--- a/src/app/things.asm
+++ b/src/app/things.asm
@@ -118,6 +118,47 @@ things_info_update::
 	ret
 
 
+; Build up to date colliders from current Thing state.
+; @mut: AF, BC, DE, HL
+things_update_colliders::
+	ld a, [wThingsInfo.count]
+	and a
+	ret z
+	ld e, a
+	ld hl, wThings
+.loop_things
+	ld a, [hl]
+	bit bThingStatus_VOID, a
+	jr nz, .loop_things_continue
+	and fThingStatus_HITS
+	jr z, .loop_things_continue
+	push hl
+	inc hl
+	ld a, [hl+] ; collider
+	cp $FF
+	jr z, .no_collider
+	ld d, a
+	ld a, [hl+] ; pos.x
+	ld b, a
+	ld a, [hl+] ; pos.y
+	ld c, a
+	ld a, d
+	call Collide_set_box_position
+.no_collider
+	pop hl
+.loop_things_continue
+	ld a, Thing_sz
+	add l
+	ld l, a
+	adc h
+	sub l
+	ld h, a
+
+	dec e
+	jr nz, .loop_things
+	ret
+
+
 ; Main Thing per-tick process routine.
 ; @mut: AF, BC, DE, HL
 things_think::

--- a/src/app/things.inc
+++ b/src/app/things.inc
@@ -237,5 +237,28 @@ macro PlaceThingLegacy
 .\@_done:
 endm
 
+; DefThingLegacy CHR, OAM_ATTR
+macro DefThingLegacy
+	ThingcNew
+	ThingcDrawOAM (\1), (\2)
+	ThingcPosition 32, 32 ; HACK: CollideTile requires position to be set
+	ThingcCollideTile
+	ThingcHits 1
+	ThingcDieGoto .state1\@
+	ThingcSave
+	ThingcStop
+.state1\@:
+	ThingcDrawOAM (\1) + 1, (\2)
+	ThingcHits 1
+	ThingcDieGoto .state2\@
+	ThingcSave
+	ThingcStop
+.state2\@:
+	ThingcDrawOAM (\1) + 2, (\2)
+	ThingcDieGoto 0
+	ThingcSave
+	ThingcStop
+endm
+
 
 endc ; APP_THINGS_INC

--- a/src/core/collide.asm
+++ b/src/core/collide.asm
@@ -109,6 +109,47 @@ Collide_set_box_max::
 	ret
 
 
+; @param B,C: new position X,Y (Left,Top)
+; @param A: index
+; @mut: AF, BC, HL
+Collide_set_box_position::
+	ld l, a
+	call Collide_get_box_at
+
+	; FALLTHROUGH
+
+; Set box position
+; @param B,C: new position X,Y (Left,Top)
+; @param HL: this
+; @mut: AF, BC, HL
+Box_set_position::
+	; dx = px - L
+	ld a, b
+	sub [hl]
+	ld b, a
+	; L' = L + dx
+	ld a, [hl]
+	add b
+	ld [hl+], a
+	; R' = R + dx
+	ld a, [hl]
+	add b
+	ld [hl+], a
+	; dy = py - T
+	ld a, c
+	sub [hl]
+	ld c, a
+	; T' = T + dy
+	ld a, [hl]
+	add c
+	ld [hl+], a
+	; B' = B + dy
+	ld a, [hl]
+	add c
+	ld [hl+], a
+	ret
+
+
 ; Set the subject collider as a 'missile'
 ; @param B,C: pX,pY missile centre
 ; @param E: missile radius

--- a/src/res/map/testmap.asm
+++ b/src/res/map/testmap.asm
@@ -10,6 +10,9 @@ def CHRSRC_A0_2     equ 2
 def CHRSRC_A1_0     equ 3
 def CHRSRC_A1_1     equ 4
 def CHRSRC_A1_2     equ 5
+def CHRSRC_A2_0     equ 6
+def CHRSRC_A2_1     equ 7
+def CHRSRC_A2_2     equ 8
 def CHRSRC_B1_0_F1  equ 18 ; (2, 1)
 def CHRSRC_B1_1_F0  equ 19 ; (3, 1)
 def CHRSRC_B1_0_F0  equ 34 ; (2, 2)
@@ -22,6 +25,9 @@ def CHR_A0_2     rb 1
 def CHR_A1_0     rb 1
 def CHR_A1_1     rb 1
 def CHR_A1_2     rb 1
+def CHR_A2_0     rb 1
+def CHR_A2_1     rb 1
+def CHR_A2_2     rb 1
 def CHR_B1_0_F1  rb 1
 def CHR_B1_1_F0  rb 1
 def CHR_B1_0_F0  rb 1
@@ -40,6 +46,16 @@ sprite_B1_1:
 sprite_B1_2:
 	SpritePart 0, 0, CHR_B1_2_F0, 0
 	SpriteEnd
+
+
+thing_A0:
+	DefThingLegacy CHR_A0_0, 0
+
+thing_A1:
+	DefThingLegacy CHR_A1_0, 32
+
+thing_A2:
+	DefThingLegacy CHR_A2_0, 0
 
 thing_B1_0:
 	ThingcNew
@@ -114,7 +130,11 @@ map_testmap::
 	db LOADOCODE_SRC
 	dw res_map_buildings_2bpp
 	db LOADOCODE_SRC_CHR, CHRSRC_A0_0
-	db LOADOCODE_CHRCOPY, 6
+	db LOADOCODE_CHRCOPY, 3
+	db LOADOCODE_SRC_CHR, CHRSRC_A1_0
+	db LOADOCODE_CHRCOPY, 3
+	db LOADOCODE_SRC_CHR, CHRSRC_A2_0
+	db LOADOCODE_CHRCOPY, 3
 	db LOADOCODE_SRC_CHR, CHRSRC_B1_0_F1
 	db LOADOCODE_CHRCOPY, 2
 	db LOADOCODE_SRC_CHR, CHRSRC_B1_0_F0
@@ -161,47 +181,21 @@ map_testmap::
 		db 132, 132, 133, 133, 134, 134, 135, 135, 136, 136, 137, 138, 139, 139, 140, 141
 
 .chunk5:
-	dw .chunk6 ; next chunk
-	db MapChunk_Things
-	.things:
-		PlaceThingLegacy 61, 92, CHR_A1_0, 32
-		PlaceThingLegacy 96, 106, CHR_A1_0, 32
-		ThingcStop
-
-.chunk6:
 	dw .chunkEnd ; next chunk
 	db MapChunk_Things
-	.things2:
-	.c6t0:
-		ThingcNew
-		ThingcDrawOAM CHR_A0_0, 0
-		ThingcPosition 119, 112
-		ThingcCollideTile
-		ThingcDieGoto .c6t0_destroyed0
-		ThingcSave
-		ThingcGoto .c6t2
-	.c6t0_destroyed0:
-		ThingcDrawOAM CHR_A0_1, 0
-		ThingcHits 1
-		ThingcDieGoto .c6t0_destroyed1
-		ThingcSave
-		ThingcStop
-	.c6t0_destroyed1:
-		ThingcDrawOAM CHR_A0_2, 0
-		ThingcDieGoto 0
-		ThingcSave
-		ThingcStop
-
-	.c6t2:
-		ThingcInstance thing_B1_0
-		ThingcPosition 137, 116
-		ThingcCollideTile ; hack: reapply collider because we moved the thing
-		ThingcSave
-		ThingcGoto .c6things_end
-
-	.c6things_end:
-		ThingcStop
-
+	ThingcInstance thing_A0
+	ThingcPosition 119, 112
+	ThingcSave
+	ThingcInstance thing_A1
+	ThingcPosition 92, 61
+	ThingcSave
+	ThingcInstance thing_A2
+	ThingcPosition 106, 96
+	ThingcSave
+	ThingcInstance thing_B1_0
+	ThingcPosition 137, 116
+	ThingcSave
+	ThingcStop
 
 .chunkEnd:
 	dw 0 ; next chunk

--- a/tools/mesen/debug-collision.lua
+++ b/tools/mesen/debug-collision.lua
@@ -214,7 +214,7 @@ function CollidersPrintInfo(colliders, cfg)
       collx, colly = coll.box.left * drawScale, coll.box.top * drawScale
       local collcol = colliderGetColor(coll)
       emu.drawLine(x, y, collx, colly, collcol)
-      emu.drawString(x, y - 8, i .. ":" .. coll.result, textColor, 0x66 | collcol)
+      emu.drawString(x, y - 8, (i - 1) .. ":" .. coll.result, textColor, 0x66 | collcol)
       popoutcount = popoutcount + 1
     end
   end


### PR DESCRIPTION
This enables Things to be moved without manually (in Thingcode) rebuilding the collider afterwards (fixes #45).
This makes it easier to share Thingcode programs as Thing definitions.
Note that the current implementation of `CollideTile` clamps the upper bounds to 255, which is the initial value of the position components. This means that the Thing's position must be set to a smaller value before generating the collider.

The Things in the testmap are now all spawned using `ThingcInstance`. (although the definitions are in the map's data)