### PR TITLE
dev branch omnibus: Thing events, Thing tags, colliders, boxes, mappy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ res/%.scrn: tools/scrn.sh res/%.png
 	@$(MKDIR_P) $(@D)
 	$^ $@
 
-res/map/%.asm: res/map/%.tmx
+res/map/%.asm: res/map/%.tmx tools/map.py
 	@$(MKDIR_P) $(@D)
 	$(MAPPY) -o $@ $<
 

--- a/src/app/thing_machine.asm
+++ b/src/app/thing_machine.asm
@@ -167,6 +167,7 @@ tcm_step::
 	dw _tcx_CollideBox
 	; tc1
 	dw _tcx_Hits
+	dw _tcx_Tag
 	; tc2
 	dw _tcx_Goto
 	dw _tcx_Instance
@@ -272,6 +273,13 @@ _tcx_Hits::
 	and ~fThingStatus_HITS
 	or d
 	ld [hl], a
+	ret
+
+
+; @param D: new ID tag value
+_tcx_Tag::
+	ld a, d
+	ld [wThingCache.tag], a
 	ret
 
 

--- a/src/app/things.asm
+++ b/src/app/things.asm
@@ -85,7 +85,6 @@ things_init_next::
 
 
 things_start::
-things_info_update::
 	ld a, [wThingsInfo.count]
 	and a
 	ret z

--- a/src/app/things.asm
+++ b/src/app/things.asm
@@ -373,3 +373,46 @@ endr
 	dec e
 	jr nz, .loop_things
 	ret
+
+
+; Find the first Thing with a tag matching the provided value.
+; @param B: query tag
+; @mut: AF, C, HL
+; @return F.C: set if no match found
+; @return HL: found Thing*
+TagThings_query_tag::
+	ld a, [wThingsInfo.count]
+	and a
+	jr z, .not_found
+	ld c, a
+	ld hl, wThings
+.loop
+	bit bThingStatus_VOID, [hl]
+	jr nz, .continue
+	inc hl      ; .status
+	ld a, [hl-] ; .tag
+	cp b
+	ret z ; return NC (CP set Z so must be)
+.continue
+	ld a, Thing_sz
+	add l
+	ld l, a
+	adc h
+	sub l
+	ld h, a
+	dec c
+	jr nz, .loop
+.not_found
+	ld hl, 0
+	scf
+	ret
+
+
+; Mark the Thing with tag as destroyed (if found).
+; @param B: query tag
+; @mut: AF, C, HL
+TagThings_kill::
+	call TagThings_query_tag
+	ret c
+	set bThingStatus_EV_DIE, [hl]
+	ret

--- a/src/app/things.asm
+++ b/src/app/things.asm
@@ -9,10 +9,10 @@ wThingsInfo::
 	.just_hit::  db ; number of things that were hit in the most recent update
 	.just_died:: db ; number of things that died in the most recent update
 	.targets::   db ; number of things that are targets
-	.count::     db
-	.next::      dw ; pointer to end of wThings array
+	.count:      db
+	.next:       dw ; pointer to end of wThings array
 
-wThings:: ds THINGS_BUFFER_SIZE
+wThings: ds THINGS_BUFFER_SIZE
 
 section "ThingCache", hram
 hThingCache:

--- a/src/app/things.inc
+++ b/src/app/things.inc
@@ -240,7 +240,7 @@ macro ThingcDieGoto
 endm
 
 
-; PlaceThingLegacy POS_Y, POS_X, CHR, OAM_ATTR
+; DefThingLegacy CHR, OAM_ATTR
 ;
 ; A Thingcode template for creating Things that behave as the original Things
 ; (pre-Thingcode) did. Uses a single OAM entry and a generated 8x8 collider.
@@ -249,30 +249,6 @@ endm
 ; When hit, the CHR used to draw it is incremented by one. This happens twice,
 ; so Tile data must be layed out accordingly, with the provided CHR being the
 ; initial state, followed by two successively more destroyed versions.
-macro PlaceThingLegacy
-	ThingcNew
-	ThingcDrawOAM (\3), (\4)
-	ThingcPosition (\2), (\1)
-	ThingcCollideTile
-	ThingcHits 1
-	ThingcDieGoto .\@_0
-	ThingcSave
-	ThingcGoto .\@_done
-.\@_0:
-	ThingcDrawOAM (\3) + 1, (\4)
-	ThingcHits 1
-	ThingcDieGoto .\@_1
-	ThingcSave
-	ThingcStop
-.\@_1:
-	ThingcDrawOAM (\3) + 2, (\4)
-	ThingcDieGoto 0
-	ThingcSave
-	ThingcStop
-.\@_done:
-endm
-
-; DefThingLegacy CHR, OAM_ATTR
 macro DefThingLegacy
 	ThingcNew
 	ThingcDrawOAM (\1), (\2)
@@ -293,6 +269,5 @@ macro DefThingLegacy
 	ThingcSave
 	ThingcStop
 endm
-
 
 endc ; APP_THINGS_INC

--- a/src/app/things.inc
+++ b/src/app/things.inc
@@ -13,6 +13,13 @@ destroyed by the player (by hitting the Ballder into them).
 An instance of a Thing (entity).
 
 
+***************************************************************** Thing ID Tag *
+Thing instances have a one byte ID tag. These can be used as handles/references.
+- usage is optional
+- user allocates/assigns IDs
+- valid ID tags are unique
+
+
 *********************************************************** Thing.status: bits *
 HITS        ( 0, 2 )
 	The number of hits the Thing takes before it dies.
@@ -54,12 +61,14 @@ def ThingsMax equ 16
 
 	stdecl Thing
 		stfield status      ; Thing status flags
+		stfield tag         ; ID tag
 		stfield collider    ; collider index
 		stfield pos, 2      ; 2D position vector
 		stfield draw_mode
 		stfield drawable, 2
 		stfield on_die, w   ; jump to here when destroyed
 	stclose
+
 
 ; Thing.status constants
 
@@ -87,6 +96,12 @@ rsreset
 def fThingDrawMode_OAM      rb 1 ; Drawable is OAM object { CHR, ATTR }
 def fThingDrawMode_Sprite   rb 1 ; Drawable is pointer to Sprite
 def fThingDrawMode__COUNT   rb 0
+
+
+; Thing.tag
+
+; The default tag
+def ThingTag_UNSET equ $FF
 
 
 ; ThingMachine status flags
@@ -118,6 +133,7 @@ def tc_CollideTile    rb 1
 def tc_CollideBox     rb 1
 def tc1               rb 0
 def tc_Hits           rb 1
+def tc_Tag            rb 1
 def tc2               rb 0
 def tc_Goto           rb 1
 def tc_Instance       rb 1
@@ -173,6 +189,12 @@ macro ThingcHits
 	assert fatal, _NARG == 1
 	assert fatal, (\1) <= fThingStatus_HITS
 	db tc_Hits, (\1)
+endm
+
+
+macro ThingcTag
+	assert fatal, _NARG == 1
+	db tc_Tag, (\1)
 endm
 
 

--- a/src/app/things.inc
+++ b/src/app/things.inc
@@ -113,7 +113,9 @@ def tc0               rb 0
 def tc_New            rb 1
 def tc_Save           rb 1
 def tc_Stop           rb 1
+def tc_CollideNone    rb 1
 def tc_CollideTile    rb 1
+def tc_CollideBox     rb 1
 def tc1               rb 0
 def tc_Hits           rb 1
 def tc2               rb 0
@@ -123,7 +125,6 @@ def tc_Position       rb 1
 def tc_DrawOAM        rb 1
 def tc_DrawSprite     rb 1
 def tc_DieGoto        rb 1
-; def tc_CollideBox     rb 1
 
 def tc__COUNT         rb 0 ; Number of instructions
 
@@ -175,9 +176,21 @@ macro ThingcHits
 endm
 
 
+macro ThingcCollideNone
+	assert fatal, _NARG == 0
+	db tc_CollideNone
+endm
+
+
 macro ThingcCollideTile
 	assert fatal, _NARG == 0
 	db tc_CollideTile
+endm
+
+
+macro ThingcCollideBox
+	assert fatal, _NARG == 4
+	db tc_CollideBox, \#
 endm
 
 
@@ -241,7 +254,6 @@ endm
 macro DefThingLegacy
 	ThingcNew
 	ThingcDrawOAM (\1), (\2)
-	ThingcPosition 32, 32 ; HACK: CollideTile requires position to be set
 	ThingcCollideTile
 	ThingcHits 1
 	ThingcDieGoto .state1\@

--- a/src/core/collide.asm
+++ b/src/core/collide.asm
@@ -129,7 +129,7 @@ Collide_set_box_max::
 
 ; @param B,C: new position X,Y (Left,Top)
 ; @param A: index
-; @mut: AF, BC, HL
+; @mut: AF, BC, DE, HL
 Collide_set_box_position::
 	ld l, a
 	call Collide_get_box_at

--- a/src/res/map/buildings.tsx
+++ b/src/res/map/buildings.tsx
@@ -1,65 +1,172 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tileset version="1.10" tiledversion="1.10.1" name="buildings" class="fg" tilewidth="8" tileheight="8" tilecount="48" columns="16">
+<tileset version="1.10" tiledversion="1.10.2" name="buildings" class="fg" tilewidth="8" tileheight="8" tilecount="48" columns="16">
  <properties>
   <property name="gigantgolf_tileset" value="fg"/>
  </properties>
  <image source="buildings.png" width="128" height="24"/>
  <tile id="0">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="2" y="1" width="5" height="7"/>
+  </objectgroup>
   <animation>
    <frame tileid="0" duration="500"/>
    <frame tileid="1" duration="500"/>
    <frame tileid="2" duration="500"/>
   </animation>
  </tile>
+ <tile id="1">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="3" width="7" height="5"/>
+  </objectgroup>
+ </tile>
  <tile id="3">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="0" width="7" height="8"/>
+  </objectgroup>
   <animation>
    <frame tileid="3" duration="500"/>
    <frame tileid="4" duration="500"/>
    <frame tileid="5" duration="500"/>
   </animation>
  </tile>
+ <tile id="4">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="3" width="8" height="5"/>
+  </objectgroup>
+ </tile>
  <tile id="6">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="1" width="8" height="7"/>
+  </objectgroup>
   <animation>
    <frame tileid="6" duration="500"/>
    <frame tileid="7" duration="500"/>
    <frame tileid="8" duration="500"/>
   </animation>
  </tile>
+ <tile id="7">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="3" width="8" height="5"/>
+  </objectgroup>
+ </tile>
  <tile id="9">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="1" width="8" height="7"/>
+  </objectgroup>
   <animation>
    <frame tileid="9" duration="500"/>
    <frame tileid="10" duration="500"/>
    <frame tileid="11" duration="500"/>
   </animation>
  </tile>
+ <tile id="10">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="2" width="8" height="6"/>
+  </objectgroup>
+ </tile>
  <tile id="12">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="1" width="7" height="7"/>
+  </objectgroup>
   <animation>
    <frame tileid="12" duration="500"/>
    <frame tileid="13" duration="500"/>
    <frame tileid="14" duration="500"/>
   </animation>
  </tile>
+ <tile id="13">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="3" width="8" height="5"/>
+  </objectgroup>
+ </tile>
  <tile id="16">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="2" y="1" width="3" height="7"/>
+  </objectgroup>
   <animation>
    <frame tileid="16" duration="500"/>
    <frame tileid="57" duration="1000"/>
   </animation>
  </tile>
+ <tile id="17">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="1" width="7" height="7"/>
+  </objectgroup>
+ </tile>
  <tile id="18">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="4" width="4" height="4"/>
+  </objectgroup>
   <animation>
    <frame tileid="18" duration="500"/>
    <frame tileid="57" duration="500"/>
    <frame tileid="57" duration="500"/>
   </animation>
  </tile>
+ <tile id="19">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="1" width="6" height="7"/>
+  </objectgroup>
+ </tile>
  <tile id="20">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="2" y="1" width="5" height="7"/>
+  </objectgroup>
   <animation>
    <frame tileid="20" duration="500"/>
    <frame tileid="57" duration="500"/>
    <frame tileid="57" duration="500"/>
   </animation>
  </tile>
+ <tile id="21">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="1" width="7" height="7"/>
+  </objectgroup>
+ </tile>
+ <tile id="22">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="2" y="2" width="6" height="6"/>
+  </objectgroup>
+ </tile>
+ <tile id="23">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="0" width="8" height="8"/>
+  </objectgroup>
+ </tile>
+ <tile id="24">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="3" y="1" width="4" height="7"/>
+  </objectgroup>
+ </tile>
+ <tile id="25">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="2" width="8" height="6"/>
+  </objectgroup>
+ </tile>
+ <tile id="26">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="3" y="3" width="5" height="5"/>
+  </objectgroup>
+ </tile>
+ <tile id="27">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="2" width="6" height="6"/>
+  </objectgroup>
+ </tile>
+ <tile id="28">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="1" width="6" height="7"/>
+  </objectgroup>
+ </tile>
+ <tile id="30">
+  <objectgroup draworder="index" id="2">
+   <object id="2" x="1" y="1" width="6" height="7"/>
+  </objectgroup>
+ </tile>
  <tile id="32">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="0" width="7" height="8"/>
+  </objectgroup>
   <animation>
    <frame tileid="32" duration="500"/>
    <frame tileid="17" duration="500"/>
@@ -67,6 +174,9 @@
   </animation>
  </tile>
  <tile id="34">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="0" width="6" height="8"/>
+  </objectgroup>
   <animation>
    <frame tileid="34" duration="500"/>
    <frame tileid="19" duration="500"/>
@@ -74,10 +184,38 @@
   </animation>
  </tile>
  <tile id="36">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="0" width="6" height="8"/>
+  </objectgroup>
   <animation>
    <frame tileid="36" duration="500"/>
    <frame tileid="21" duration="500"/>
    <frame tileid="37" duration="500"/>
   </animation>
+ </tile>
+ <tile id="38">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="0" width="7" height="8"/>
+  </objectgroup>
+ </tile>
+ <tile id="40">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="0" width="8" height="8"/>
+  </objectgroup>
+ </tile>
+ <tile id="42">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="0" y="0" width="8" height="8"/>
+  </objectgroup>
+ </tile>
+ <tile id="44">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="2" width="6" height="6"/>
+  </objectgroup>
+ </tile>
+ <tile id="46">
+  <objectgroup draworder="index" id="2">
+   <object id="1" type="CollisionShape" x="1" y="2" width="6" height="6"/>
+  </objectgroup>
  </tile>
 </tileset>

--- a/src/res/map/gigantgolf-maps.tiled-project
+++ b/src/res/map/gigantgolf-maps.tiled-project
@@ -7,6 +7,21 @@
     "folders": [
         "."
     ],
+    "properties": [
+    ],
     "propertyTypes": [
+        {
+            "color": "#ffd09ec8",
+            "drawFill": true,
+            "id": 5,
+            "members": [
+            ],
+            "name": "CollisionShape",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        }
     ]
 }

--- a/src/res/map/testmap.asm
+++ b/src/res/map/testmap.asm
@@ -60,19 +60,20 @@ thing_A2:
 thing_B1_0:
 	ThingcNew
 	ThingcDrawSprite sprite_B1_0
-	ThingcPosition 32, 32
-	ThingcCollideTile
+	ThingcCollideBox 2, 7, -3, 8
 	ThingcDieGoto thing_B1_F0_1
 	ThingcSave
 	ThingcStop
 thing_B1_F0_1:
 	ThingcDrawSprite sprite_B1_1
+	ThingcCollideTile
 	ThingcHits 1
 	ThingcDieGoto thing_B1_F0_2
 	ThingcSave
 	ThingcStop
 thing_B1_F0_2:
 	ThingcDrawSprite sprite_B1_2
+	ThingcCollideNone
 	ThingcDieGoto 0
 	ThingcSave
 	ThingcStop

--- a/tools/map.py
+++ b/tools/map.py
@@ -137,15 +137,17 @@ class LegacyThingDef:
 
 
 class ThingPlacement:
-    def __init__(self, pos_x: int, pos_y: int, thing_def):
+    def __init__(self, pos_x: int, pos_y: int, tag: int, thing_def):
         self.pos_x: int = pos_x
         self.pos_y: int = pos_y
+        self.tag: int = tag
         self.thing_def: int = thing_def
 
     def get_asm(self) -> [str]:
         return [
             f"\tThingcInstance {self.thing_def.get_def_label()}",
             f"\tThingcPosition {self.pos_x}, {self.pos_y}",
+            f"\tThingcTag {self.tag}",
             f"\tThingcSave",
         ]
 
@@ -158,7 +160,7 @@ class Things:
     def place_legacy_thing(self, pos_x: int, pos_y: int, chr_code: int, oam_attr: int):
         td = LegacyThingDef(chr_code, oam_attr)
         self.thing_defs[td.get_def_id()] = td
-        self.thing_placements.append(ThingPlacement(pos_x, pos_y, td))
+        self.thing_placements.append(ThingPlacement(pos_x, pos_y, len(self.thing_placements), td))
 
     def get_defs_asm(self) -> [str]:
         lines: [str] = []


### PR DESCRIPTION
It's a bunch of things! Some of them are related!

### Colliders:
- closes #102
- Add buffer to store collision boxes in object-local / relative coordinates.
- Setting the collider's position transforms the box and caches it.
- The cache is essentially the original `wColliders` buffer, so existing code can keep working without changes.
- Thingcode `tc_Collide*` ops now update the existing collider, if there is one.
- Add Thingcode `tc_CollideBox` -- set Thing collider as a box.
- Add Thingcode `tc_CollideNone` -- clears Thing collider.

### Map Authoring / Tiled Project:
- Add `CollisionShape` property class.
- Add `CollisionShape` boxes/rectangles to the `buildings` tileset. Part of #103.
  - Note that these are currently unused in-game.

### Refactor Things manager in preparation for Thing tags:
- More robust/defensive access and offsetting into the Thing struct.
- Various routines iterate over `wThings`. These loops were made more conformal.

### Mappy & Make:
- Separate Thing definitions and placements
- Add definition Thingcode for each unique Thing.
- Place each required Thing using `tc_Instance`.
- Is Python more scared of me than I am of it?
- Makefile: Add `map.py` as a prerequisite to the map conversion target, so changes to the tool will trigger rebuilds of the maps.

### Thing event processing:
- Clear Thing events (`EV_DIE`, `EV_HIT`) after processing them in `things_think`.
  - Previously, these were cleared in the collision processing routine -- immediately before (possibly) setting them again.
- This allows these events to be fired arbitrarily from systems other than collision processing.

### Thing Tags -- optional ID tags / handles:
- Add `tag` field to `Thing`.
- Add Thingcode op to set tag: `tc_Tag`, `ThingcTag`.
- mappy: apply unique tags to thing instances
- Add `TagThings_query_tag` to find a Thing instance with a given tag.
- Add `TagThings_kill` simple function to kill the Thing with matching
  tag. Note that nothing is using this currently, but it has been tested
  and is to be used for destroying subthings. See #104.
- Introduce the `TagThings_` prefix for all your TagThings needs.