### PR TITLE
mappy: Thing parents & various improvements

### DIFF
--- a/tools/map.py
+++ b/tools/map.py
@@ -72,6 +72,9 @@ class TileSource:
         """Return range of GIDs contained by this tileset."""
         return range(self.tileset.firstgid, self.tileset.firstgid + self.tileset.tile_count)
 
+    def has_gid(self, gid: int) -> bool:
+        return (gid & MASK_GID) in self.get_gid_range()
+
     def get_res_path(self) -> Path:
         """
         return Tileset source image ChrSource resource path
@@ -101,18 +104,17 @@ class MapTileset:
 class TileTracker:
     def __init__(self):
         self.sources: [TileSource] = []
-        self.gid_to_source: dict = {}
 
     def add_source_tilesets(self, tmx: TiledMap):
         for tileset in tmx.tilesets.values():
             source = TileSource(tileset)
             self.sources.append(source)
-            for gid in source.get_gid_range():
-                self.gid_to_source[gid] = source
 
     def require_gid_source(self, gid: int) -> TileSource:
-        assert gid & MASK_GID in self.gid_to_source
-        return self.gid_to_source[gid & MASK_GID]
+        for source in self.sources:
+            if source.has_gid(gid):
+                return source
+        return None
 
     def build_tileset_loadocode(self, tileset: MapTileset, block: int) -> [str]:
         if tileset.is_empty():

--- a/tools/map.py
+++ b/tools/map.py
@@ -405,10 +405,10 @@ class Map:
     @staticmethod
     def gid_to_bg_attr(gid: int) -> int:
         oam_attr = 0
-        if obj.gid & GID_FLIPPED_VERT:
-            oam_attr |= OAM_FLIP_VERT
-        if obj.gid & GID_FLIPPED_HORI:
-            oam_attr |= OAM_FLIP_HORI
+        if gid & GID_FLIPPED_VERT:
+            bg_attr |= BG_FLIP_VERT
+        if gid & GID_FLIPPED_HORI:
+            bg_attr |= BG_FLIP_HORI
         return oam_attr
 
     @staticmethod

--- a/tools/map.py
+++ b/tools/map.py
@@ -14,38 +14,32 @@ from pytiled_parser.tiled_map import TiledMap, Tileset
 from pytiled_parser.layer import TileLayer, ObjectLayer
 
 
-# Tileset custom property key
-PROP_TILESET = "gigantgolf_tileset"
-# Identifies a tileset as the terrain/background tileset...
-TILESET_BG = "bg"
-# Identifies a tileset as the building/object tileset...
-TILESET_FG = "fg"
 CLASS_LAYER_FG = "fg"
 CLASS_LAYER_BG = "bg"
 # 'class' of the tee-off location object
 CLASS_TEE_OFF = "tee_off"
 CLASS_HEIGHTMAP_CONTOUR = "heightmap_contour"
 
-MASK_GID = 0x0fffffff
-MASK_GID_FLAGS = 0xf0000000
-GID_FLIPPED_HORI = 0x80000000
-GID_FLIPPED_VERT = 0x40000000
-GID_FLIPPED_DIAG = 0x20000000
-GID_ROTATED_HEX_120 = 0x10000000
 
-BGATTR_PRIORITY  = 0x80
-BGATTR_FLIP_VERT = 0x40
-BGATTR_FLIP_HORI = 0x20
-_BGATTR_UNUSED   = 0x10
-BGATTR_BANK      = 0x08
-BGATTR_PAL_COL   = 0x07
+MASK_GID             = 0x0fffffff
+GID_FLIPPED_HORI     = 0x80000000
+GID_FLIPPED_VERT     = 0x40000000
+GID_FLIPPED_DIAG     = 0x20000000
+GID_ROTATED_HEX_120  = 0x10000000
 
-OAM_PRIORITY = 0x80
-OAM_FLIP_VERT = 0x40
-OAM_FLIP_HORI = 0x20
-OAM_PAL_DMG = 0x10
-OAM_CHR_BANK = 0x08
-OAM_PAL_COL = 0x07
+BGATTR_PRIORITY      = 0x80
+BGATTR_FLIP_VERT     = 0x40
+BGATTR_FLIP_HORI     = 0x20
+_BGATTR_UNUSED       = 0x10
+BGATTR_BANK          = 0x08
+BGATTR_PAL_COL       = 0x07
+
+OAM_PRIORITY         = 0x80
+OAM_FLIP_VERT        = 0x40
+OAM_FLIP_HORI        = 0x20
+OAM_PAL_DMG          = 0x10
+OAM_CHR_BANK         = 0x08
+OAM_PAL_COL          = 0x07
 
 
 LOG_LEVEL_VERBOSE = -1


### PR DESCRIPTION
### Things:
- resolve parents in TiledObject properties
- build Rules chunk with `RUL_SUBTHING(parent, child)` for each linked pair (part of #104)

### Move several things out of `Map` class:
- Tiles chunk build routine to `TileTracker`
- GID to CHR mapping to `MapTileset`
- Thing chunk generation to `Things`

### Also:
- corrected GID to BG attr conversion
- simplified `TileTracker` GID to `TileSource` lookup
- tidied up constants up the top & removed some unused ones