### PR TITLE
LevelSelect: Disable UI nav sound

### DIFF
--- a/src/app/level_select.asm
+++ b/src/app/level_select.asm
@@ -98,8 +98,6 @@ LevelSelect.main_iter::
 	jr z, :+
 	ld a, d
 	ld [wSettings.level], a
-	ld hl, snd_ui_move
-	call sound_play
 	call LevelSelect_refresh0
 	call LevelSelect_refresh1
 	call LevelSelect_refresh2

--- a/src/app/sound_test.asm
+++ b/src/app/sound_test.asm
@@ -5,7 +5,7 @@ section "SoundTest", rom0
 
 ; @mut: AF, BC, DE, HL, ROMB
 SoundTest_init::
-	ld a, bank(TileData)
+	PushRomb bank(TileData)
 	rst rom_sel
 	ld de, TileData
 	ld hl, $8800
@@ -29,6 +29,8 @@ SoundTest_init::
 	ld a, h
 	cp $9C ; end = $9C00
 	jr nz, .patternloop
+
+	PopRomb
 
 	xor a
 	ld [wSelection], a

--- a/src/app/sounds.asm
+++ b/src/app/sounds.asm
@@ -8,18 +8,11 @@ section "Sounds", romx
 ***********************************************************/
 
 snd_ui_move::
-	ScPart CH2, 2, :+
-	ScReg rNR21, $80 | 16
-	ScReg rNR22, $A1
-	ScReg rNR23, low(E06)
-	ScReg rNR24, high(E06) | $C0
-	ScEnd
-:
-	ScPart CH2, 5
+	ScPart CH2, 1
 	ScReg rNR21, $80 | 16
 	ScReg rNR22, $81
-	ScReg rNR23, low(F06)
-	ScReg rNR24, high(F06) | $C0
+	ScReg rNR23, low(Fs7)
+	ScReg rNR24, high(Fs7) | $C0
 	ScEnd
 
 snd_ui_nav_enter::
@@ -187,4 +180,6 @@ snd_smash_04::
 /***********************************************************
 *                                              Sound Table *
 ***********************************************************/
+
+section "SoundTable", rom0
 	SoundTableEnd sound_table_size::, sound_table::


### PR DESCRIPTION
- Move sound_table to rom0, so banking not required to lookup sounds.
- Make ui nav sound really short

Fixes #119 